### PR TITLE
chore: remove pre-deployed preview url

### DIFF
--- a/apps/csk-v-next/content/previewUrl/16b9087e-477a-4fc5-808d-f0f929b1a82b.yaml
+++ b/apps/csk-v-next/content/previewUrl/16b9087e-477a-4fc5-808d-f0f929b1a82b.yaml
@@ -1,4 +1,4 @@
 id: 16b9087e-477a-4fc5-808d-f0f929b1a82b
 name: Local
 url: http://localhost:3000/api/preview?secret=hello-world
-order: 1
+order: 0

--- a/apps/csk-v-next/content/previewUrl/dc1b5e15-5d38-46ab-8700-f2c34cfde634.yaml
+++ b/apps/csk-v-next/content/previewUrl/dc1b5e15-5d38-46ab-8700-f2c34cfde634.yaml
@@ -1,4 +1,0 @@
-id: dc1b5e15-5d38-46ab-8700-f2c34cfde634
-name: Staging
-url: https://dev-csk-v-next-approuter.vercel.app/api/preview?secret=hello-world
-order: 0

--- a/apps/csk-v-next/package.json
+++ b/apps/csk-v-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csk-v-next",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csk-v-next-packages",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csk-v-next-packages",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -25,7 +25,7 @@
       }
     },
     "apps/csk-v-next": {
-      "version": "2.0.12",
+      "version": "2.0.13",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "20.1.0",
         "@uniformdev/csk-components": "*",
@@ -12357,7 +12357,7 @@
     },
     "packages/csk-cli": {
       "name": "@uniformdev/csk-cli",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -12390,7 +12390,7 @@
     },
     "packages/csk-components": {
       "name": "@uniformdev/csk-components",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -12432,7 +12432,7 @@
     },
     "packages/csk-recipes": {
       "name": "@uniformdev/csk-recipes",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -12465,7 +12465,7 @@
     },
     "packages/design-extensions-tools": {
       "name": "@uniformdev/design-extensions-tools",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -12494,7 +12494,7 @@
     },
     "packages/eslint-config": {
       "name": "@repo/eslint-config",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@next/eslint-plugin-next": "^15.1.6",
@@ -12515,7 +12515,7 @@
     },
     "packages/typescript-config": {
       "name": "@repo/typescript-config",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csk-v-next-packages",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "private": true,
   "scripts": {
     "build": "turbo build",

--- a/packages/csk-cli/package.json
+++ b/packages/csk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-cli",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Command-line interface (CLI) tool designed to streamline the development workflow within Uniform projects. It provides commands for pulling additional data and generating components based on Canvas data",
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "./cli.js",

--- a/packages/csk-components/package.json
+++ b/packages/csk-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-components",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Components Starter Kit that provides a set of basic components for building websites within a Uniform project",
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "./cli.js",

--- a/packages/csk-recipes/package.json
+++ b/packages/csk-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-recipes",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "command-line interface (CLI) and utility functions to help you work with recipes in a CSK project. It simplifies project initialization by allowing you to choose templates and include specific recipes",
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "./cli.js",

--- a/packages/design-extensions-tools/package.json
+++ b/packages/design-extensions-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/design-extensions-tools",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Command-line interface (CLI) tool and a set of utilities for working with design extension integrations",
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "./cli.js",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/eslint-config",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/typescript-config",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "private": true,
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
This is not working anyways with app router, makes an impression of a broken preview/editor.
Details posted here:
https://uniformdev.slack.com/archives/C05836MUN1K/p1738246607797629