### PR TITLE
feat: enhanced carousel layout & controls

### DIFF
--- a/apps/csk-marketing-site/package.json
+++ b/apps/csk-marketing-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-marketing-site",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/apps/csk-storybook/package.json
+++ b/apps/csk-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-storybook",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "description": "CSK vNext Storybook is an interactive Storybook build showcasing components from the CSK vNext component starter kit. It provides detailed documentation, live previews, and testing capabilities for easy integration into your projects.",
   "main": "index.js",
   "scripts": {

--- a/apps/csk-storybook/src/stories/canvas/components/Carousel.stories.tsx
+++ b/apps/csk-storybook/src/stories/canvas/components/Carousel.stories.tsx
@@ -1,3 +1,4 @@
+import { ReactElement } from 'react';
 import { UniformComposition } from '@uniformdev/canvas-next-rsc';
 import { Image, Carousel, CarouselParameters } from '@uniformdev/csk-components/components/canvas';
 import createComponentResolver from '@uniformdev/csk-components/utils/createComponentResolver';
@@ -21,33 +22,21 @@ const argTypes: Partial<ArgTypes<CarouselParameters>> = {
   ...baseContainerArgTypes,
 };
 
-export const Default: Story = {
-  args: {
-    displayName: 'Carousel',
-    backgroundColor: 'text-secondary',
-    fluidContent: true,
-    fullHeight: false,
-  },
-  argTypes,
-  render: (args: CarouselParameters) => {
-    const route = createFakeCompositionData(
-      'carousel',
-      undefined,
-      {
-        ...args,
-      },
-      {
-        carouselItems: Array.from({ length: 6 }, () => ({
-          type: 'image',
-          parameters: createUniformParameter({
-            image: IMAGE_ASSET,
-            objectFit: 'cover',
-            height: 500,
-            width: 500,
-          }),
-        })),
-      }
-    );
+const createCarouselItems = (count = 16) =>
+  Array.from({ length: count }, () => ({
+    type: 'image',
+    parameters: createUniformParameter({
+      image: IMAGE_ASSET,
+      objectFit: 'cover',
+      height: 500,
+      width: 500,
+    }),
+  }));
+
+const createStory = (variant?: string): ((args: CarouselParameters) => ReactElement) => {
+  return (args: CarouselParameters) => {
+    const route = createFakeCompositionData('carousel', variant, { ...args }, { carouselItems: createCarouselItems() });
+
     return (
       <UniformComposition
         serverContext={fakeContext}
@@ -61,5 +50,56 @@ export const Default: Story = {
         mode="server"
       />
     );
+  };
+};
+
+export const Default: Story = {
+  args: {
+    displayName: 'Carousel',
+    backgroundColor: 'text-secondary',
+    fluidContent: true,
+    fullHeight: false,
+    itemsPerPage: '1',
   },
+  argTypes,
+  render: createStory(),
+};
+
+export const DefaultWithMultipleItems: Story = {
+  args: {
+    displayName: 'Carousel',
+    backgroundColor: 'text-secondary',
+    fluidContent: true,
+    fullHeight: false,
+    itemsPerPage: '3',
+    gapX: '4',
+  },
+  argTypes,
+  render: createStory(),
+};
+
+export const BrochureWithMultipleItems: Story = {
+  args: {
+    displayName: 'Carousel',
+    backgroundColor: 'text-secondary',
+    fluidContent: true,
+    fullHeight: false,
+    itemsPerPage: '3',
+    gapX: '4',
+  },
+  argTypes,
+  render: createStory('brochure'),
+};
+
+export const NumericWithMultipleItems: Story = {
+  args: {
+    displayName: 'Carousel',
+    backgroundColor: 'text-secondary',
+    fluidContent: true,
+    fullHeight: false,
+    itemsPerPage: '3',
+    gapX: '4',
+  },
+  argTypes,
+  render: createStory('numeric'),
 };

--- a/apps/csk/content/component/carousel.yaml
+++ b/apps/csk/content/component/carousel.yaml
@@ -96,4 +96,7 @@ slots:
 titleParameter: displayName
 canBeComposition: false
 created: '2025-03-20T12:55:43.435513+00:00'
-updated: '2025-06-10T11:24:51.41237+00:00'
+updated: '2025-06-13T08:50:21.004546+00:00'
+variants:
+  - id: brochure
+    name: Brochure

--- a/apps/csk/content/component/carousel.yaml
+++ b/apps/csk/content/component/carousel.yaml
@@ -96,7 +96,9 @@ slots:
 titleParameter: displayName
 canBeComposition: false
 created: '2025-03-20T12:55:43.435513+00:00'
-updated: '2025-06-13T08:50:21.004546+00:00'
+updated: '2025-06-13T09:53:23.696497+00:00'
 variants:
   - id: brochure
     name: Brochure
+  - id: numeric
+    name: Numeric

--- a/apps/csk/content/component/carousel.yaml
+++ b/apps/csk/content/component/carousel.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=<https://uniform.app/schemas/json-schema/component-definition/v1.json>
+# yaml-language-server: $schema=https://uniform.app/schemas/json-schema/component-definition/v1.json
 $schema: https://uniform.app/schemas/json-schema/component-definition/v1.json
 id: carousel
 name: Carousel
@@ -15,11 +15,45 @@ parameters:
     typeConfig:
       collapsed: true
       childrenParams:
+        - itemsPerPage
+        - gapX
         - backgroundColor
         - spacing
         - border
         - fluidContent
         - fullHeight
+  - id: itemsPerPage
+    name: Items Per Page
+    type: dex-slider-control-parameter
+    typeConfig:
+      step: 1
+      type: steps
+      units: ''
+      maxValue: 4
+      minValue: 1
+      defaultValue: '1'
+  - id: gapX
+    name: Gap X
+    type: dex-slider-control-parameter
+    typeConfig:
+      step: 1
+      type: custom
+      unit: px
+      options:
+        - key: XSmall
+          value: '2'
+        - key: Small
+          value: '4'
+        - key: Medium
+          value: '8'
+        - key: Large
+          value: '16'
+        - key: XLarge
+          value: '32'
+      maxValue: 10
+      minValue: 0
+      defaultValue: {}
+      withViewPort: true
   - id: backgroundColor
     name: Background Color
     type: dex-color-palette-parameter
@@ -61,5 +95,5 @@ slots:
     patternsInAllowedComponents: false
 titleParameter: displayName
 canBeComposition: false
-created: '2025-01-29T10:47:01.262734+00:00'
-updated: '2025-02-19T10:34:31.98631+00:00'
+created: '2025-03-20T12:55:43.435513+00:00'
+updated: '2025-06-10T11:24:51.41237+00:00'

--- a/apps/csk/package.json
+++ b/apps/csk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/component-starter-kit",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/apps/csk/tailwind.config.ts
+++ b/apps/csk/tailwind.config.ts
@@ -13,6 +13,9 @@ import utilities from './tailwind.utilities.json';
 const safelist = [
   { pattern: /grid-cols-(1[0-2]|[1-9]|none|subgrid)/, variants: ['lg', 'md'] },
   { pattern: /gap(?:-(x|y))?-(0(\.5)?|1(\.5)?|2(\.5)?|3(\.5)?|[1-9]?[0-9]|px)/, variants: ['lg', 'md'] },
+  { pattern: /px?-([0-9]+|0(\.5)?|1(\.5)?|2(\.5)?|3(\.5)?|px)/, variants: ['lg', 'md'] },
+  { pattern: /mx?-([0-9]+|0(\.5)?|1(\.5)?|2(\.5)?|3(\.5)?|px)/, variants: ['lg', 'md'] },
+  { pattern: /-mx?-[0-9]+/, variants: ['lg', 'md'] },
   { pattern: /flex-(col|row|col-reverse|row-reverse)/, variants: ['lg', 'md'] },
   { pattern: /justify-(normal|start|end|center|between|around|evenly|stretch)/, variants: ['lg', 'md'] },
   { pattern: /items-(start|end|center|baseline|stretch)/, variants: ['lg', 'md'] },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csk-packages",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csk-packages",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/csk": {
       "name": "@uniformdev/component-starter-kit",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "^20.20.0",
         "@uniformdev/csk-components": "*",
@@ -67,7 +67,7 @@
     },
     "apps/csk-marketing-site": {
       "name": "@uniformdev/csk-marketing-site",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "^20.20.0",
         "@uniformdev/csk-components": "*",
@@ -109,7 +109,7 @@
     },
     "apps/csk-storybook": {
       "name": "@uniformdev/csk-storybook",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.3",
         "@repo/eslint-config": "*",
@@ -22602,7 +22602,7 @@
     },
     "packages/csk-cli": {
       "name": "@uniformdev/csk-cli",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -22769,7 +22769,7 @@
     },
     "packages/csk-components": {
       "name": "@uniformdev/csk-components",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -22947,7 +22947,7 @@
     },
     "packages/csk-recipes": {
       "name": "@uniformdev/csk-recipes",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23132,7 +23132,7 @@
     },
     "packages/design-extensions-tools": {
       "name": "@uniformdev/design-extensions-tools",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23296,7 +23296,7 @@
     },
     "packages/eslint-config": {
       "name": "@repo/eslint-config",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@next/eslint-plugin-next": "^15.3.2",
@@ -23330,7 +23330,7 @@
     },
     "packages/typescript-config": {
       "name": "@repo/typescript-config",
-      "version": "6.0.82",
+      "version": "6.0.83",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csk-packages",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "private": true,
   "scripts": {
     "build": "turbo build",

--- a/packages/csk-cli/package.json
+++ b/packages/csk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-cli",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "description": "Command-line interface (CLI) tool designed to streamline the development workflow within Uniform projects. It provides commands for pulling additional data and generating components based on Canvas data",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/csk-components/package.json
+++ b/packages/csk-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-components",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "description": "Components Starter Kit that provides a set of basic components for building websites within a Uniform project",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/csk-components/src/components/canvas/Carousel/carousel.tsx
+++ b/packages/csk-components/src/components/canvas/Carousel/carousel.tsx
@@ -15,9 +15,10 @@ export const Carousel: FC<CarouselProps> = ({
   fluidContent,
   fullHeight,
   itemsPerPage,
+  gapX,
 }) => (
   <BaseCarousel
-    {...{ backgroundColor, spacing, border, fluidContent, fullHeight, itemsPerPage }}
+    {...{ backgroundColor, spacing, border, fluidContent, fullHeight, itemsPerPage, gapX }}
     countOfItems={slots.carouselItems?.items.length ?? 0}
   >
     {({ className, style }) => (

--- a/packages/csk-components/src/components/canvas/Carousel/carousel.tsx
+++ b/packages/csk-components/src/components/canvas/Carousel/carousel.tsx
@@ -1,15 +1,9 @@
 'use client';
 
 import { FC } from 'react';
-import { UniformSlot, CustomSlotChildRenderFunc } from '@uniformdev/canvas-next-rsc/component';
+import { UniformSlot } from '@uniformdev/canvas-next-rsc/component';
 import BaseCarousel from '@/components/ui/Carousel';
 import { CarouselProps } from '.';
-
-const itemRenderFunc: CustomSlotChildRenderFunc = ({ child, key }) => (
-  <div key={key} className="flex size-full min-w-full items-center justify-center">
-    {child}
-  </div>
-);
 
 export const Carousel: FC<CarouselProps> = ({
   slots,
@@ -20,13 +14,20 @@ export const Carousel: FC<CarouselProps> = ({
   border,
   fluidContent,
   fullHeight,
+  itemsPerPage,
 }) => (
   <BaseCarousel
-    {...{ backgroundColor, spacing, border, fluidContent, fullHeight }}
+    {...{ backgroundColor, spacing, border, fluidContent, fullHeight, itemsPerPage }}
     countOfItems={slots.carouselItems?.items.length ?? 0}
   >
-    <UniformSlot context={context} slot={slots.carouselItems} data={component}>
-      {itemRenderFunc}
-    </UniformSlot>
+    {({ className, style }) => (
+      <UniformSlot context={context} slot={slots.carouselItems} data={component}>
+        {({ child, key }) => (
+          <div key={key} className={className} style={style}>
+            {child}
+          </div>
+        )}
+      </UniformSlot>
+    )}
   </BaseCarousel>
 );

--- a/packages/csk-components/src/components/canvas/Carousel/carousel.tsx
+++ b/packages/csk-components/src/components/canvas/Carousel/carousel.tsx
@@ -20,6 +20,7 @@ export const Carousel: FC<CarouselProps> = ({
   <BaseCarousel
     {...{ backgroundColor, spacing, border, fluidContent, fullHeight, itemsPerPage, gapX }}
     countOfItems={slots.carouselItems?.items.length ?? 0}
+    variant={component.variant}
   >
     {({ className, style }) => (
       <UniformSlot context={context} slot={slots.carouselItems} data={component}>

--- a/packages/csk-components/src/components/canvas/Carousel/index.tsx
+++ b/packages/csk-components/src/components/canvas/Carousel/index.tsx
@@ -2,7 +2,9 @@ import dynamic from 'next/dynamic';
 import { ComponentProps } from '@uniformdev/canvas-next-rsc/component';
 import { ContainerParameters } from '@/components/canvas/Container/parameters';
 
-export type CarouselParameters = ContainerParameters;
+export type CarouselParameters = ContainerParameters & {
+  itemsPerPage: string;
+};
 
 export enum CarouselSlots {
   Items = 'carouselItems',

--- a/packages/csk-components/src/components/canvas/Carousel/index.tsx
+++ b/packages/csk-components/src/components/canvas/Carousel/index.tsx
@@ -4,6 +4,7 @@ import { ContainerParameters } from '@/components/canvas/Container/parameters';
 
 export type CarouselParameters = ContainerParameters & {
   itemsPerPage: string;
+  gapX: string;
 };
 
 export enum CarouselSlots {

--- a/packages/csk-components/src/components/ui/Carousel/carousel.tsx
+++ b/packages/csk-components/src/components/ui/Carousel/carousel.tsx
@@ -56,11 +56,7 @@ export const Carousel: FC<CarouselProps> = ({
   const renderCarouselButtons = () => {
     if (variant === CarouselVariant.BROCHURE) {
       return (
-        <div
-          className={cn('flex py-4 px-4 z-5 gap-x-4 justify-end items-center', {
-            [`bg-${backgroundColor}`]: !!backgroundColor,
-          })}
-        >
+        <div className={cn('flex py-4 px-4 z-5 gap-x-4 justify-end items-center', {})}>
           <button onClick={handlerPreviousNextButton}>❮</button>
 
           <div className="flex items-center gap-2">
@@ -76,6 +72,22 @@ export const Carousel: FC<CarouselProps> = ({
                 aria-label={`Go to slide ${index + 1}`}
               />
             ))}
+          </div>
+          <button onClick={handlerClickNextButton}>❯</button>
+        </div>
+      );
+    }
+    if (variant === CarouselVariant.NUMERIC) {
+      return (
+        <div
+          className={cn('flex py-4 px-4 z-5 gap-x-4 justify-end items-center', {
+            [`text-${backgroundColor} invert`]: !!backgroundColor,
+            'text-black dark:text-white': !backgroundColor,
+          })}
+        >
+          <button onClick={handlerPreviousNextButton}>❮</button>
+          <div className="flex flex-col px-2">
+            {currentIndex + 1} of {totalCountOfItems}
           </div>
           <button onClick={handlerClickNextButton}>❯</button>
         </div>

--- a/packages/csk-components/src/components/ui/Carousel/carousel.tsx
+++ b/packages/csk-components/src/components/ui/Carousel/carousel.tsx
@@ -2,11 +2,8 @@
 
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import BaseContainer from '@/components/ui/Container';
-import { cn } from '@/utils/styling';
+import { cn, resolveViewPort } from '@/utils/styling';
 import { CarouselProps } from '.';
-
-// 16px - gap-x-4, we have to divide it by 2 because we have 2 gaps
-const GAP_SIZE = 16;
 
 export const Carousel: FC<CarouselProps> = ({
   countOfItems,
@@ -17,6 +14,7 @@ export const Carousel: FC<CarouselProps> = ({
   fullHeight,
   itemsPerPage = '1',
   children,
+  gapX,
 }) => {
   const container = useRef<HTMLDivElement>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -30,15 +28,6 @@ export const Carousel: FC<CarouselProps> = ({
     }
     return countOfItems ?? 0;
   }, [countOfItems, itemsPerPageNumber]);
-
-  const totalGapSize = useMemo(() => {
-    if (itemsPerPageNumber > 1) {
-      const totalSize = GAP_SIZE * (itemsPerPageNumber - 1);
-
-      return Math.ceil(totalSize / itemsPerPageNumber);
-    }
-    return 0;
-  }, [itemsPerPageNumber]);
 
   useEffect(() => {
     const handleResize = () => setReCheckCarouselSlider(prev => !prev);
@@ -80,20 +69,21 @@ export const Carousel: FC<CarouselProps> = ({
 
   const renderSlides = () => {
     return children({
-      className: 'flex size-full items-center justify-center',
-      style: { minWidth: itemsPerPageNumber > 1 ? `calc(${100 / itemsPerPageNumber}% - ${totalGapSize}px)` : '100%' },
+      className: cn('flex size-full items-center justify-center', {
+        [resolveViewPort(gapX, 'px-{value}')]: gapX,
+      }),
+      style: { minWidth: itemsPerPageNumber > 1 ? `calc(${100 / itemsPerPageNumber}%)` : '100%' },
     });
   };
 
   return (
     <BaseContainer {...{ backgroundColor, spacing, border, fluidContent, fullHeight }}>
-      <div className="relative">
-        <div
-          ref={container}
-          className={cn('flex overflow-x-hidden scroll-smooth', {
-            'gap-x-4': itemsPerPageNumber > 1,
-          })}
-        >
+      <div
+        className={cn('relative', {
+          [resolveViewPort(gapX, '-mx-{value}')]: gapX,
+        })}
+      >
+        <div ref={container} className="flex overflow-x-hidden scroll-smooth">
           {renderSlides()}
         </div>
         {renderCarouselButtons()}

--- a/packages/csk-components/src/components/ui/Carousel/carousel.tsx
+++ b/packages/csk-components/src/components/ui/Carousel/carousel.tsx
@@ -3,7 +3,7 @@
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import BaseContainer from '@/components/ui/Container';
 import { cn, resolveViewPort } from '@/utils/styling';
-import { CarouselProps } from '.';
+import { CarouselProps, CarouselVariant } from '.';
 
 export const Carousel: FC<CarouselProps> = ({
   countOfItems,
@@ -15,6 +15,7 @@ export const Carousel: FC<CarouselProps> = ({
   itemsPerPage = '1',
   children,
   gapX,
+  variant = CarouselVariant.DEFAULT,
 }) => {
   const container = useRef<HTMLDivElement>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -52,8 +53,35 @@ export const Carousel: FC<CarouselProps> = ({
     [totalCountOfItems]
   );
 
-  const renderCarouselButtons = useCallback(
-    () => (
+  const renderCarouselButtons = () => {
+    if (variant === CarouselVariant.BROCHURE) {
+      return (
+        <div
+          className={cn('flex py-4 px-4 z-5 gap-x-4 justify-end items-center', {
+            [`bg-${backgroundColor}`]: !!backgroundColor,
+          })}
+        >
+          <button onClick={handlerPreviousNextButton}>❮</button>
+
+          <div className="flex items-center gap-2">
+            {Array.from({ length: totalCountOfItems }).map((_, index) => (
+              <button
+                key={`slide-${index}`}
+                onClick={() => setCurrentIndex(index)}
+                className={cn('h-2 rounded-full transition-all duration-300 size-2 opacity-50', {
+                  'w-6 opacity-100': index === currentIndex,
+                  [`bg-${backgroundColor} invert`]: !!backgroundColor,
+                  'bg-black dark:bg-white': !backgroundColor,
+                })}
+                aria-label={`Go to slide ${index + 1}`}
+              />
+            ))}
+          </div>
+          <button onClick={handlerClickNextButton}>❯</button>
+        </div>
+      );
+    }
+    return (
       <div
         className={cn('absolute inset-x-5 top-1/2 flex -translate-y-1/2 justify-between', {
           [`text-${backgroundColor} invert`]: !!backgroundColor,
@@ -63,9 +91,8 @@ export const Carousel: FC<CarouselProps> = ({
         <button onClick={handlerPreviousNextButton}>❮</button>
         <button onClick={handlerClickNextButton}>❯</button>
       </div>
-    ),
-    [backgroundColor, handlerClickNextButton, handlerPreviousNextButton]
-  );
+    );
+  };
 
   const renderSlides = () => {
     return children({

--- a/packages/csk-components/src/components/ui/Carousel/index.ts
+++ b/packages/csk-components/src/components/ui/Carousel/index.ts
@@ -10,6 +10,12 @@ export type CarouselProps = Pick<
   children: (options: { className?: string; style?: React.CSSProperties }) => ReactElement;
   itemsPerPage?: string;
   gapX?: string;
+  variant?: string;
 };
+
+export enum CarouselVariant {
+  DEFAULT = 'default',
+  BROCHURE = 'brochure',
+}
 
 export default dynamic(() => import('./carousel').then(mod => mod.Carousel));

--- a/packages/csk-components/src/components/ui/Carousel/index.ts
+++ b/packages/csk-components/src/components/ui/Carousel/index.ts
@@ -7,7 +7,8 @@ export type CarouselProps = Pick<
   'title' | 'backgroundColor' | 'spacing' | 'border' | 'fluidContent' | 'fullHeight'
 > & {
   countOfItems?: number;
-  children: ReactElement | ReactElement[];
+  children: (options: { className?: string; style?: React.CSSProperties }) => ReactElement;
+  itemsPerPage?: string;
 };
 
 export default dynamic(() => import('./carousel').then(mod => mod.Carousel));

--- a/packages/csk-components/src/components/ui/Carousel/index.ts
+++ b/packages/csk-components/src/components/ui/Carousel/index.ts
@@ -9,6 +9,7 @@ export type CarouselProps = Pick<
   countOfItems?: number;
   children: (options: { className?: string; style?: React.CSSProperties }) => ReactElement;
   itemsPerPage?: string;
+  gapX?: string;
 };
 
 export default dynamic(() => import('./carousel').then(mod => mod.Carousel));

--- a/packages/csk-components/src/components/ui/Carousel/index.ts
+++ b/packages/csk-components/src/components/ui/Carousel/index.ts
@@ -16,6 +16,7 @@ export type CarouselProps = Pick<
 export enum CarouselVariant {
   DEFAULT = 'default',
   BROCHURE = 'brochure',
+  NUMERIC = 'numeric',
 }
 
 export default dynamic(() => import('./carousel').then(mod => mod.Carousel));

--- a/packages/csk-recipes/package.json
+++ b/packages/csk-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-recipes",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "description": "command-line interface (CLI) and utility functions to help you work with recipes in a CSK project. It simplifies project initialization by allowing you to choose templates and include specific recipes",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/design-extensions-tools/package.json
+++ b/packages/design-extensions-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/design-extensions-tools",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "description": "Command-line interface (CLI) tool and a set of utilities for working with design extension integrations",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/eslint-config",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/typescript-config",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "private": true,
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Previously, the Carousel component only supported displaying a single item per slide. I introduced two new parameters:
	•	itemsPerPage – controls how many items are shown per slide
	•	gapX – defines the horizontal spacing between carousel items

These updates enable support for multi-item carousels, improving flexibility for various content use cases.

Additionally, I implemented two new arrow navigation variants:
	•	brochure – styled for marketing/promotional layouts
	•	numeric – displays numbered slide controls

The Storybook stories have also been updated to reflect these enhancements and showcase usage of the new props and variants.

![CleanShot 2025-06-13 at 13 01 01](https://github.com/user-attachments/assets/a0dfab92-7e0f-4920-a707-db20ad6c8df3)
![CleanShot 2025-06-13 at 13 01 14](https://github.com/user-attachments/assets/6d5bd107-f280-4814-b240-e75ebda588ef)
![CleanShot 2025-06-13 at 13 01 20](https://github.com/user-attachments/assets/9797096d-8d62-4f3b-b315-54c8ecb1ec7c)