### PR TITLE
feat(image): split logic into "fill" and "default" variants with fallback size resolution

### DIFF
--- a/apps/csk-marketing-site/package.json
+++ b/apps/csk-marketing-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-marketing-site",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/apps/csk-storybook/package.json
+++ b/apps/csk-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-storybook",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "description": "CSK vNext Storybook is an interactive Storybook build showcasing components from the CSK vNext component starter kit. It provides detailed documentation, live previews, and testing capabilities for easy integration into your projects.",
   "main": "index.js",
   "scripts": {

--- a/apps/csk/content/component/image.yaml
+++ b/apps/csk/content/component/image.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=<https://uniform.app/schemas/json-schema/component-definition/v1.json>
+# yaml-language-server: $schema=https://uniform.app/schemas/json-schema/component-definition/v1.json
 $schema: https://uniform.app/schemas/json-schema/component-definition/v1.json
 id: image
 name: Image
@@ -24,24 +24,24 @@ parameters:
     type: dex-segmented-control-parameter
     typeConfig:
       options:
-        - key: Fill
-          value: fill
         - key: Contain
           value: contain
         - key: Cover
           value: cover
-        - key: None
-          value: none
-        - key: Scale Down
-          value: scale-down
       defaultValue: cover
   - id: width
     name: Width
     type: number
+    helpText: >-
+      Sets the image’s intrinsic width in pixels. This does not control how
+      large the image appears
     typeConfig: null
   - id: height
     name: Height
     type: number
+    helpText: >-
+      Sets the image’s intrinsic height in pixels. This does not control how
+      large the image appears
     typeConfig: null
   - id: 6a821149-f836-49f2-806c-db36ecc79dc8
     name: Loading Settings
@@ -116,5 +116,8 @@ slots: []
 titleParameter: image
 thumbnailParameter: image
 canBeComposition: false
-created: '2025-02-17T15:34:14.681024+00:00'
-updated: '2025-02-17T15:34:14.681024+00:00'
+created: '2025-03-20T12:55:44.383837+00:00'
+updated: '2025-06-16T12:52:11.394466+00:00'
+variants:
+  - id: background
+    name: Background

--- a/apps/csk/content/component/image.yaml
+++ b/apps/csk/content/component/image.yaml
@@ -19,6 +19,7 @@ parameters:
         - objectFit
         - width
         - height
+        - fill
   - id: objectFit
     name: Object Fit
     type: dex-segmented-control-parameter
@@ -33,15 +34,20 @@ parameters:
     name: Width
     type: number
     helpText: >-
-      Sets the image’s intrinsic width in pixels. This does not control how
-      large the image appears
+      Defines intrinsic width (not visual size). For 'background' variant, helps
+      set focal point.
     typeConfig: null
   - id: height
     name: Height
     type: number
     helpText: >-
-      Sets the image’s intrinsic height in pixels. This does not control how
-      large the image appears
+      Defines intrinsic height (not visual size). For 'background' variant,
+      helps set focal point.
+    typeConfig: null
+  - id: fill
+    name: Fill
+    type: checkbox
+    helpText: Fills the parent container
     typeConfig: null
   - id: 6a821149-f836-49f2-806c-db36ecc79dc8
     name: Loading Settings
@@ -117,7 +123,4 @@ titleParameter: image
 thumbnailParameter: image
 canBeComposition: false
 created: '2025-03-20T12:55:44.383837+00:00'
-updated: '2025-06-16T12:52:11.394466+00:00'
-variants:
-  - id: fill
-    name: Fill
+updated: '2025-06-19T14:23:44.458359+00:00'

--- a/apps/csk/content/component/image.yaml
+++ b/apps/csk/content/component/image.yaml
@@ -119,5 +119,5 @@ canBeComposition: false
 created: '2025-03-20T12:55:44.383837+00:00'
 updated: '2025-06-16T12:52:11.394466+00:00'
 variants:
-  - id: background
-    name: Background
+  - id: fill
+    name: Fill

--- a/apps/csk/package.json
+++ b/apps/csk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/component-starter-kit",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csk-packages",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csk-packages",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/csk": {
       "name": "@uniformdev/component-starter-kit",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "^20.20.3",
         "@uniformdev/csk-components": "*",
@@ -67,7 +67,7 @@
     },
     "apps/csk-marketing-site": {
       "name": "@uniformdev/csk-marketing-site",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "^20.20.3",
         "@uniformdev/csk-components": "*",
@@ -109,7 +109,7 @@
     },
     "apps/csk-storybook": {
       "name": "@uniformdev/csk-storybook",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.3",
         "@repo/eslint-config": "*",
@@ -22700,7 +22700,7 @@
     },
     "packages/csk-cli": {
       "name": "@uniformdev/csk-cli",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -22867,7 +22867,7 @@
     },
     "packages/csk-components": {
       "name": "@uniformdev/csk-components",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23047,7 +23047,7 @@
     },
     "packages/csk-recipes": {
       "name": "@uniformdev/csk-recipes",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23232,7 +23232,7 @@
     },
     "packages/design-extensions-tools": {
       "name": "@uniformdev/design-extensions-tools",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23396,7 +23396,7 @@
     },
     "packages/eslint-config": {
       "name": "@repo/eslint-config",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@next/eslint-plugin-next": "^15.3.2",
@@ -23430,7 +23430,7 @@
     },
     "packages/typescript-config": {
       "name": "@repo/typescript-config",
-      "version": "6.0.88",
+      "version": "6.0.89",
       "license": "MIT"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6660,6 +6660,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/needle": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-UFIuc1gdyzAqeVUYpSL+cliw2MmU/ZUhVZKE7Zo4wPbgc8hbljeKSnn6ls6iG8r5jpegPXLUIhJ+Wb2kLVs8cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.17.47",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.47.tgz",
@@ -6676,6 +6686,17 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/probe-image-size": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@types/probe-image-size/-/probe-image-size-7.2.5.tgz",
+      "integrity": "sha512-9Bg6d/GNnjmhMMxadDstwrSlquuuLf0jQuPszbU6n3QUfybif3V/ryD3J2i9iaiC5JB/FU/8E41n88SM/UB+Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/needle": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.4",
@@ -15614,7 +15635,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.mergewith": {
@@ -16268,7 +16288,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -16332,6 +16351,44 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/needle/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -18173,6 +18230,17 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -19439,6 +19507,12 @@
         }
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -20174,6 +20248,30 @@
         "readable-stream": "^3.6.0",
         "xtend": "^4.0.2"
       }
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -22781,6 +22879,7 @@
         "next-themes": "^0.4.4",
         "ora": "^8.1.1",
         "prettier": "3.5.2",
+        "probe-image-size": "^7.2.3",
         "react-player": "^2.16.0",
         "react-responsive-masonry": "^2.7.0",
         "tailwind-merge": "^2.5.2"
@@ -22791,6 +22890,7 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@types/probe-image-size": "^7.2.5",
         "@uniformdev/assets": "^20.20.3",
         "@uniformdev/canvas": "^20.20.3",
         "@uniformdev/canvas-next-rsc": "^20.20.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csk-packages",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "private": true,
   "scripts": {
     "build": "turbo build",

--- a/packages/csk-cli/package.json
+++ b/packages/csk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-cli",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "description": "Command-line interface (CLI) tool designed to streamline the development workflow within Uniform projects. It provides commands for pulling additional data and generating components based on Canvas data",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/csk-components/package.json
+++ b/packages/csk-components/package.json
@@ -70,6 +70,7 @@
     "next-themes": "^0.4.4",
     "ora": "^8.1.1",
     "prettier": "3.5.2",
+    "probe-image-size": "^7.2.3",
     "react-player": "^2.16.0",
     "react-responsive-masonry": "^2.7.0",
     "tailwind-merge": "^2.5.2"
@@ -77,6 +78,7 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@types/probe-image-size": "^7.2.5",
     "@uniformdev/assets": "^20.20.3",
     "@uniformdev/canvas": "^20.20.3",
     "@uniformdev/canvas-next-rsc": "^20.20.3",

--- a/packages/csk-components/package.json
+++ b/packages/csk-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-components",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "description": "Components Starter Kit that provides a set of basic components for building websites within a Uniform project",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/csk-components/src/components/canvas/Image/image.tsx
+++ b/packages/csk-components/src/components/canvas/Image/image.tsx
@@ -15,12 +15,11 @@ export const Image: FC<ImageProps> = async ({
   overlayOpacity,
   border,
   priority,
+  fill,
   unoptimized,
   context,
   component,
 }) => {
-  const isFill = component.variant === 'fill';
-
   const [resolvedImage] = resolveAsset(image);
 
   if (!resolvedImage) {
@@ -46,7 +45,7 @@ export const Image: FC<ImageProps> = async ({
     })
     .url();
 
-  const variantBasedProps = isFill
+  const variantBasedProps = fill
     ? { fill: true }
     : {
         width: imageWidth || fallbackSize.width,

--- a/packages/csk-components/src/components/canvas/Image/image.tsx
+++ b/packages/csk-components/src/components/canvas/Image/image.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { imageFrom } from '@uniformdev/assets';
 import BaseImage from '@/components/ui/Image';
 import { resolveAsset } from '@/utils/assets';
 import { ImageProps } from '.';
@@ -17,20 +18,33 @@ export const Image: FC<ImageProps> = ({
   context,
   component,
 }) => {
+  const isBackground = component.variant === 'background';
+
   const [resolvedImage] = resolveAsset(image);
 
   if (!resolvedImage) {
     return <ImagePlaceholder context={context} component={component} width={width} height={height} />;
   }
 
-  const { url, title = '' } = resolvedImage;
+  const { focalPoint, title = '' } = resolvedImage;
+
+  const imageUrl = imageFrom(resolvedImage?.url)
+    .transform({
+      width: width,
+      height: height,
+      fit: objectFit,
+      focal: focalPoint,
+    })
+    .url();
+
+  const variantBasedProps = isBackground
+    ? { fill: true }
+    : { width: width || resolvedImage.width, height: height || resolvedImage.height };
 
   return (
     <BaseImage
-      containerStyle={{ ...(width ? { width: `${width}px` } : {}), ...(height ? { height: `${height}px` } : {}) }}
-      src={url}
+      src={imageUrl}
       alt={title}
-      fill
       unoptimized={unoptimized}
       priority={priority}
       sizes="100%"
@@ -38,6 +52,7 @@ export const Image: FC<ImageProps> = ({
       overlayColor={overlayColor}
       overlayOpacity={overlayOpacity}
       border={border}
+      {...variantBasedProps}
     />
   );
 };

--- a/packages/csk-components/src/components/canvas/Image/index.tsx
+++ b/packages/csk-components/src/components/canvas/Image/index.tsx
@@ -12,6 +12,7 @@ export type ImageParameters = {
   border?: string | ViewPort<string>;
   priority?: boolean;
   unoptimized?: boolean;
+  fill?: boolean;
 };
 
 export type ImageProps = ComponentProps<ImageParameters>;

--- a/packages/csk-components/src/utils/assets.ts
+++ b/packages/csk-components/src/utils/assets.ts
@@ -11,6 +11,10 @@ type ResolvedAsset = {
   height?: number;
   mediaType?: string;
   description?: string;
+  focalPoint?: {
+    x: number;
+    y: number;
+  };
 };
 
 /**

--- a/packages/csk-recipes/package.json
+++ b/packages/csk-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-recipes",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "description": "command-line interface (CLI) and utility functions to help you work with recipes in a CSK project. It simplifies project initialization by allowing you to choose templates and include specific recipes",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/design-extensions-tools/package.json
+++ b/packages/design-extensions-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/design-extensions-tools",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "description": "Command-line interface (CLI) tool and a set of utilities for working with design extension integrations",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/eslint-config",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/typescript-config",
-  "version": "6.0.88",
+  "version": "6.0.89",
   "private": true,
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
This PR refactors the Image component logic to support two distinct variants:

 Changes:
	•	Split image rendering logic into:
	•	"fill" variant — image takes size from the parent container.
	•	"default" variant — requires explicit image dimensions.
	•	Primary image dimensions now come from Uniform assets (resolvedImage.width/height).
	•	Fallback logic added using probe-image-size to retrieve image size by URL when no size metadata is available.
	•	Focal point support integrated (used in image transformation).

 Implementation Notes:
	•	probe-image-size is used only when dimensions are missing from the asset.
	•	No impact on public API – backward compatible.