### PR TITLE
feat(image): split logic into "fill" and "default" variants with fallback size resolution

### DIFF
--- a/apps/csk-marketing-site/content/componentPattern/192fccfb-4b6b-4fbd-bd6d-e7c5234a497e.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/192fccfb-4b6b-4fbd-bd6d-e7c5234a497e.yaml
@@ -29,6 +29,9 @@ composition:
       - _id: 688fb6a0-a384-4b57-a1c1-33ada8f49db3
         type: image
         parameters:
+          fill:
+            type: checkbox
+            value: true
           image:
             type: asset
             value:
@@ -40,7 +43,7 @@ composition:
                     value: ff044480-8310-44f4-9991-82176767a172
                   url:
                     value: >-
-                      https://img.uniform.global/p/ZfA3kJm3TDeKyWey802IkQ/RIaWVdb1SW6lEURx4PYk0g-featured-bg.png
+                      https://img.uniform.global/p/4Ac1zi8UQeOXsvDsKwotZQ/FjBsimm9TZOn3dMX6sp1hg-featured-bg.png
                     type: text
                   file:
                     type: file
@@ -192,8 +195,8 @@ composition:
     parameters:
       displayName: 'yes'
     hideLockedParameters: true
-created: '2025-02-17T16:01:09.994983+00:00'
-modified: '2025-02-17T16:01:09.994983+00:00'
+created: '2025-01-29T11:28:34.593532+00:00'
+modified: '2025-06-20T13:31:24.216118+00:00'
 pattern: true
 previewImageUrl: >-
   https://res.cloudinary.com/uniform-demos/image/upload/csk-v-next/baseline/preview-images/featured-card.jpg

--- a/apps/csk-marketing-site/content/componentPattern/4a8a7a31-8425-4dee-bc8a-ba0adce84cb1.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/4a8a7a31-8425-4dee-bc8a-ba0adce84cb1.yaml
@@ -111,6 +111,9 @@ composition:
             - _id: 76b7803a-2786-4d5c-a1e3-0d80b542108e
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -173,8 +176,8 @@ composition:
       link: 'yes'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:28.309497+00:00'
-modified: '2025-03-03T09:52:28.309497+00:00'
+created: '2025-06-20T12:39:36.975076+00:00'
+modified: '2025-06-20T13:09:30.266431+00:00'
 pattern: true
 description: >-
   This example is constructed utilizing the Hero component, which incorporates a

--- a/apps/csk-marketing-site/content/componentPattern/6d0cf521-5c04-48f5-8ee8-8eab2c50835e.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/6d0cf521-5c04-48f5-8ee8-8eab2c50835e.yaml
@@ -174,6 +174,9 @@ composition:
       - _id: 0b146a50-8d3c-489f-9274-6048e43089d4
         type: image
         parameters:
+          fill:
+            type: checkbox
+            value: true
           image:
             type: asset
             value:
@@ -185,7 +188,7 @@ composition:
                     value: 0e5575b8-ef94-46c9-8567-d8ce3f4bf206
                   url:
                     value: >-
-                      https://img.uniform.global/p/ZfA3kJm3TDeKyWey802IkQ/hvhbQwotSOaMT3ue0zwRtA-Group-670.png
+                      https://img.uniform.global/p/4Ac1zi8UQeOXsvDsKwotZQ/FB_XRyjqSaWUBgJKw_frCw-Group-670.png
                     type: text
                   file:
                     type: file
@@ -215,6 +218,6 @@ composition:
         text:
           type: text
           value: Book a free demo now
-created: '2025-02-17T16:01:11.919188+00:00'
-modified: '2025-02-17T16:01:11.919188+00:00'
+created: '2025-01-29T11:28:36.529124+00:00'
+modified: '2025-06-20T13:08:38.371755+00:00'
 pattern: true

--- a/apps/csk-marketing-site/content/componentPattern/7f0d0a65-02dd-4291-8b81-fb13ae23a48d.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/7f0d0a65-02dd-4291-8b81-fb13ae23a48d.yaml
@@ -44,6 +44,9 @@ composition:
             - _id: c8a1dabe-e928-418b-9c41-88f45d6b6695
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -167,8 +170,8 @@ composition:
       spacing: 'no'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:29.093569+00:00'
-modified: '2025-03-03T09:52:29.093569+00:00'
+created: '2025-06-20T12:39:37.877702+00:00'
+modified: '2025-06-20T13:10:20.65129+00:00'
 pattern: true
 description: >-
   This example is constructed utilizing the Hero component, which incorporates

--- a/apps/csk-marketing-site/content/componentPattern/ad31c0d5-4901-4f2c-a973-409ef0fb493e.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/ad31c0d5-4901-4f2c-a973-409ef0fb493e.yaml
@@ -44,6 +44,9 @@ composition:
             - _id: f3f8c957-3d15-4c89-a15d-6b0dc1c6cad7
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -166,8 +169,8 @@ composition:
       link: 'yes'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:31.072393+00:00'
-modified: '2025-03-03T09:52:31.072393+00:00'
+created: '2025-06-20T12:39:39.874722+00:00'
+modified: '2025-06-20T13:04:43.991885+00:00'
 pattern: true
 description: >-
   This example is constructed utilizing the Hero component, which incorporates

--- a/apps/csk-marketing-site/content/componentPattern/b6b1a64a-063d-4e60-974d-f1c083ddd8dd.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/b6b1a64a-063d-4e60-974d-f1c083ddd8dd.yaml
@@ -111,6 +111,9 @@ composition:
             - _id: 5ac91a20-9ec5-4b0e-80f9-860e6fc00887
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -207,8 +210,8 @@ composition:
       link: 'yes'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:31.199025+00:00'
-modified: '2025-03-03T09:52:31.199025+00:00'
+created: '2025-06-20T12:39:40.07013+00:00'
+modified: '2025-06-20T13:04:01.730524+00:00'
 pattern: true
 description: >-
   This example is constructed utilizing the Hero component, which incorporates a

--- a/apps/csk-marketing-site/content/componentPattern/ba89404c-71eb-4690-b3a8-de4260b19239.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/ba89404c-71eb-4690-b3a8-de4260b19239.yaml
@@ -37,6 +37,9 @@ composition:
             - _id: e8107cdf-1a07-433f-a897-557f3c5bccd5
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -139,7 +142,7 @@ composition:
       link: 'yes'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:31.083218+00:00'
-modified: '2025-03-03T10:47:30.482645+00:00'
+created: '2025-06-20T12:39:40.847387+00:00'
+modified: '2025-06-20T13:02:33.138909+00:00'
 pattern: true
 categoryId: 096fd5ed-5e2a-4bfa-834b-fb805d1d1ce9

--- a/apps/csk-marketing-site/content/componentPattern/c83614e9-1a4c-41b6-9a16-9b07cc341d07.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/c83614e9-1a4c-41b6-9a16-9b07cc341d07.yaml
@@ -44,6 +44,9 @@ composition:
             - _id: 64fa10f0-d43c-408e-b09a-1783f2e77398
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -158,8 +161,8 @@ composition:
       backgroundColor: 'no'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:32.091248+00:00'
-modified: '2025-03-03T10:39:40.126656+00:00'
+created: '2025-06-20T12:39:41.850306+00:00'
+modified: '2025-06-20T12:59:54.031647+00:00'
 pattern: true
 description: >-
   This example is constructed utilizing the Hero component, which incorporates

--- a/apps/csk-marketing-site/content/componentPattern/db9c43cb-1bc0-43a1-bfd0-96b6aca664d3.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/db9c43cb-1bc0-43a1-bfd0-96b6aca664d3.yaml
@@ -37,6 +37,9 @@ composition:
             - _id: 24da591f-710f-4796-9a05-b032b6cd8243
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -154,8 +157,8 @@ composition:
       link: 'yes'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:33.375009+00:00'
-modified: '2025-03-03T09:52:33.375009+00:00'
+created: '2025-06-20T12:39:42.80432+00:00'
+modified: '2025-06-20T12:50:57.27766+00:00'
 pattern: true
 description: >-
   This example is constructed utilizing the Hero component, which incorporates a

--- a/apps/csk-marketing-site/content/componentPattern/ec3d2ee4-f077-4158-aab0-4c3c5bf5cf81.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/ec3d2ee4-f077-4158-aab0-4c3c5bf5cf81.yaml
@@ -111,6 +111,9 @@ composition:
             - _id: 5ac91a20-9ec5-4b0e-80f9-860e6fc00887
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -122,7 +125,7 @@ composition:
                           value: ff044480-8310-44f4-9991-82176767a172
                         url:
                           value: >-
-                            https://img.uniform.global/p/ZfA3kJm3TDeKyWey802IkQ/RIaWVdb1SW6lEURx4PYk0g-featured-bg.png
+                            https://img.uniform.global/p/4Ac1zi8UQeOXsvDsKwotZQ/FjBsimm9TZOn3dMX6sp1hg-featured-bg.png
                           type: text
                         file:
                           type: file
@@ -195,8 +198,8 @@ composition:
       link: 'yes'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:33.385075+00:00'
-modified: '2025-03-03T09:52:33.385075+00:00'
+created: '2025-06-20T12:39:42.905667+00:00'
+modified: '2025-06-20T12:49:29.247614+00:00'
 pattern: true
 description: >-
   This example is constructed utilizing the Hero component, which incorporates a

--- a/apps/csk-marketing-site/content/componentPattern/eea0b9bb-82f4-4de6-9aa5-af290540615d.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/eea0b9bb-82f4-4de6-9aa5-af290540615d.yaml
@@ -54,6 +54,9 @@ composition:
                     rule: $qk
                     value: dark
                     source: theme
+          fill:
+            type: checkbox
+            value: true
           image:
             type: asset
             value:
@@ -124,6 +127,9 @@ composition:
                     rule: $qk
                     value: dark
                     source: theme
+          fill:
+            type: checkbox
+            value: true
           image:
             type: asset
             value:
@@ -293,7 +299,7 @@ composition:
       backgroundColor: 'yes'
     hideLockedParameters: true
 created: '2025-01-29T11:28:36.539102+00:00'
-modified: '2025-02-24T18:46:01.88028+00:00'
+modified: '2025-06-20T12:41:50.798771+00:00'
 pattern: true
 previewImageUrl: >-
   https://res.cloudinary.com/uniform-demos/image/upload/csk-v-next/baseline/preview-images/main-hero.jpg

--- a/apps/csk-marketing-site/content/componentPattern/f9a92fbf-51cc-4385-b06a-73087f151463.yaml
+++ b/apps/csk-marketing-site/content/componentPattern/f9a92fbf-51cc-4385-b06a-73087f151463.yaml
@@ -37,6 +37,9 @@ composition:
             - _id: 24da591f-710f-4796-9a05-b032b6cd8243
               type: image
               parameters:
+                fill:
+                  type: checkbox
+                  value: true
                 image:
                   type: asset
                   value:
@@ -54,6 +57,9 @@ composition:
                 border:
                   type: dex-token-selector-parameter
                   value: border-image-radius-medium
+                objectFit:
+                  type: dex-segmented-control-parameter
+                  value: cover
               _overridability:
                 hideLockedParameters: true
           reviewContent:
@@ -152,8 +158,8 @@ composition:
       link: 'yes'
       enableComponentPreview: 'yes'
     hideLockedParameters: true
-created: '2025-03-03T09:52:34.039176+00:00'
-modified: '2025-03-03T09:52:34.039176+00:00'
+created: '2025-06-20T12:39:42.872386+00:00'
+modified: '2025-06-20T12:50:23.684123+00:00'
 pattern: true
 description: >-
   This example is constructed utilizing the Hero component, which incorporates a

--- a/apps/csk-marketing-site/package.json
+++ b/apps/csk-marketing-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-marketing-site",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/apps/csk-storybook/package.json
+++ b/apps/csk-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-storybook",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "description": "CSK vNext Storybook is an interactive Storybook build showcasing components from the CSK vNext component starter kit. It provides detailed documentation, live previews, and testing capabilities for easy integration into your projects.",
   "main": "index.js",
   "scripts": {

--- a/apps/csk/content/component/image.yaml
+++ b/apps/csk/content/component/image.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=<https://uniform.app/schemas/json-schema/component-definition/v1.json>
+# yaml-language-server: $schema=https://uniform.app/schemas/json-schema/component-definition/v1.json
 $schema: https://uniform.app/schemas/json-schema/component-definition/v1.json
 id: image
 name: Image
@@ -19,29 +19,35 @@ parameters:
         - objectFit
         - width
         - height
+        - fill
   - id: objectFit
     name: Object Fit
     type: dex-segmented-control-parameter
     typeConfig:
       options:
-        - key: Fill
-          value: fill
         - key: Contain
           value: contain
         - key: Cover
           value: cover
-        - key: None
-          value: none
-        - key: Scale Down
-          value: scale-down
       defaultValue: cover
   - id: width
     name: Width
     type: number
+    helpText: >-
+      Defines intrinsic width (not visual size). For 'background' variant, helps
+      set focal point.
     typeConfig: null
   - id: height
     name: Height
     type: number
+    helpText: >-
+      Defines intrinsic height (not visual size). For 'background' variant,
+      helps set focal point.
+    typeConfig: null
+  - id: fill
+    name: Fill
+    type: checkbox
+    helpText: Fills the parent container
     typeConfig: null
   - id: 6a821149-f836-49f2-806c-db36ecc79dc8
     name: Loading Settings
@@ -116,5 +122,5 @@ slots: []
 titleParameter: image
 thumbnailParameter: image
 canBeComposition: false
-created: '2025-02-17T15:34:14.681024+00:00'
-updated: '2025-02-17T15:34:14.681024+00:00'
+created: '2025-03-20T12:55:44.383837+00:00'
+updated: '2025-06-19T14:23:44.458359+00:00'

--- a/apps/csk/package.json
+++ b/apps/csk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/component-starter-kit",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csk-packages",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csk-packages",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/csk": {
       "name": "@uniformdev/component-starter-kit",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "^20.20.3",
         "@uniformdev/csk-components": "*",
@@ -67,7 +67,7 @@
     },
     "apps/csk-marketing-site": {
       "name": "@uniformdev/csk-marketing-site",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "^20.20.3",
         "@uniformdev/csk-components": "*",
@@ -109,7 +109,7 @@
     },
     "apps/csk-storybook": {
       "name": "@uniformdev/csk-storybook",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.3",
         "@repo/eslint-config": "*",
@@ -22602,7 +22602,7 @@
     },
     "packages/csk-cli": {
       "name": "@uniformdev/csk-cli",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -22769,7 +22769,7 @@
     },
     "packages/csk-components": {
       "name": "@uniformdev/csk-components",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -22947,7 +22947,7 @@
     },
     "packages/csk-recipes": {
       "name": "@uniformdev/csk-recipes",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23132,7 +23132,7 @@
     },
     "packages/design-extensions-tools": {
       "name": "@uniformdev/design-extensions-tools",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23296,7 +23296,7 @@
     },
     "packages/eslint-config": {
       "name": "@repo/eslint-config",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@next/eslint-plugin-next": "^15.3.2",
@@ -23330,7 +23330,7 @@
     },
     "packages/typescript-config": {
       "name": "@repo/typescript-config",
-      "version": "6.0.90",
+      "version": "6.0.91",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csk-packages",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "private": true,
   "scripts": {
     "build": "turbo build",

--- a/packages/csk-cli/package.json
+++ b/packages/csk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-cli",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "description": "Command-line interface (CLI) tool designed to streamline the development workflow within Uniform projects. It provides commands for pulling additional data and generating components based on Canvas data",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/csk-components/package.json
+++ b/packages/csk-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-components",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "description": "Components Starter Kit that provides a set of basic components for building websites within a Uniform project",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/csk-components/src/components/canvas/Image/image.tsx
+++ b/packages/csk-components/src/components/canvas/Image/image.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react';
+import { imageFrom } from '@uniformdev/assets';
 import BaseImage from '@/components/ui/Image';
 import { resolveAsset } from '@/utils/assets';
 import { ImageProps } from '.';
 import { ImagePlaceholder } from './placeholder';
 
-export const Image: FC<ImageProps> = ({
+export const Image: FC<ImageProps> = async ({
   image,
   objectFit,
   width,
@@ -13,6 +14,7 @@ export const Image: FC<ImageProps> = ({
   overlayOpacity,
   border,
   priority,
+  fill,
   unoptimized,
   context,
   component,
@@ -23,14 +25,38 @@ export const Image: FC<ImageProps> = ({
     return <ImagePlaceholder context={context} component={component} width={width} height={height} />;
   }
 
-  const { url, title = '' } = resolvedImage;
+  const { focalPoint, title = '' } = resolvedImage;
+
+  const imageWidth = width || resolvedImage.width;
+  const imageHeight = height || resolvedImage.height;
+
+  if (!fill && (!imageWidth || !imageHeight)) {
+    console.warn(
+      'No dimensions provided for the Next.js Image component. Falling back to a standard <img> tag for rendering.'
+    );
+    return <img src={resolvedImage.url} alt={title} />;
+  }
+
+  const imageUrl = imageFrom(resolvedImage?.url)
+    .transform({
+      width: width,
+      height: height,
+      fit: objectFit,
+      focal: focalPoint,
+    })
+    .url();
+
+  const variantBasedProps = fill
+    ? { fill: true }
+    : {
+        width: imageWidth,
+        height: imageHeight,
+      };
 
   return (
     <BaseImage
-      containerStyle={{ ...(width ? { width: `${width}px` } : {}), ...(height ? { height: `${height}px` } : {}) }}
-      src={url}
+      src={imageUrl}
       alt={title}
-      fill
       unoptimized={unoptimized}
       priority={priority}
       sizes="100%"
@@ -38,6 +64,7 @@ export const Image: FC<ImageProps> = ({
       overlayColor={overlayColor}
       overlayOpacity={overlayOpacity}
       border={border}
+      {...variantBasedProps}
     />
   );
 };

--- a/packages/csk-components/src/components/canvas/Image/index.tsx
+++ b/packages/csk-components/src/components/canvas/Image/index.tsx
@@ -12,6 +12,7 @@ export type ImageParameters = {
   border?: string | ViewPort<string>;
   priority?: boolean;
   unoptimized?: boolean;
+  fill?: boolean;
 };
 
 export type ImageProps = ComponentProps<ImageParameters>;

--- a/packages/csk-components/src/utils/assets.ts
+++ b/packages/csk-components/src/utils/assets.ts
@@ -11,6 +11,10 @@ type ResolvedAsset = {
   height?: number;
   mediaType?: string;
   description?: string;
+  focalPoint?: {
+    x: number;
+    y: number;
+  };
 };
 
 /**

--- a/packages/csk-recipes/package.json
+++ b/packages/csk-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-recipes",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "description": "command-line interface (CLI) and utility functions to help you work with recipes in a CSK project. It simplifies project initialization by allowing you to choose templates and include specific recipes",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/design-extensions-tools/package.json
+++ b/packages/design-extensions-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/design-extensions-tools",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "description": "Command-line interface (CLI) tool and a set of utilities for working with design extension integrations",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/eslint-config",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/typescript-config",
-  "version": "6.0.90",
+  "version": "6.0.91",
   "private": true,
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
This PR refactors the Image component logic to support two distinct variants:

Changes:
• Split image rendering logic into:
• "fill" variant — image takes size from the parent container.
• "default" variant — requires explicit image dimensions.
• Primary image dimensions now come from Uniform assets (resolvedImage.width/height).
• Fallback logic added using probe-image-size to retrieve image size by URL when no size metadata is available.
• Focal point support integrated (used in image transformation).

Implementation Notes:
• probe-image-size is used only when dimensions are missing from the asset.
• No impact on public API – backward compatible.