### PR TITLE
chore: alight fixed hero title size according to other components/pat…

### DIFF
--- a/apps/csk-marketing-site/package.json
+++ b/apps/csk-marketing-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-marketing-site",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/apps/csk-storybook/package.json
+++ b/apps/csk-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-storybook",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "description": "CSK vNext Storybook is an interactive Storybook build showcasing components from the CSK vNext component starter kit. It provides detailed documentation, live previews, and testing capabilities for easy integration into your projects.",
   "main": "index.js",
   "scripts": {

--- a/apps/csk/package.json
+++ b/apps/csk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/component-starter-kit",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "private": true,
   "engines": {
     "yarn": "please-use-npm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csk-packages",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csk-packages",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/csk": {
       "name": "@uniformdev/component-starter-kit",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "^20.20.3",
         "@uniformdev/csk-components": "*",
@@ -67,7 +67,7 @@
     },
     "apps/csk-marketing-site": {
       "name": "@uniformdev/csk-marketing-site",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "dependencies": {
         "@uniformdev/canvas-next-rsc": "^20.20.3",
         "@uniformdev/csk-components": "*",
@@ -109,7 +109,7 @@
     },
     "apps/csk-storybook": {
       "name": "@uniformdev/csk-storybook",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.3",
         "@repo/eslint-config": "*",
@@ -22602,7 +22602,7 @@
     },
     "packages/csk-cli": {
       "name": "@uniformdev/csk-cli",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -22769,7 +22769,7 @@
     },
     "packages/csk-components": {
       "name": "@uniformdev/csk-components",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -22947,7 +22947,7 @@
     },
     "packages/csk-recipes": {
       "name": "@uniformdev/csk-recipes",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23132,7 +23132,7 @@
     },
     "packages/design-extensions-tools": {
       "name": "@uniformdev/design-extensions-tools",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -23296,7 +23296,7 @@
     },
     "packages/eslint-config": {
       "name": "@repo/eslint-config",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@next/eslint-plugin-next": "^15.3.2",
@@ -23330,7 +23330,7 @@
     },
     "packages/typescript-config": {
       "name": "@repo/typescript-config",
-      "version": "6.0.101",
+      "version": "6.0.102",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csk-packages",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "private": true,
   "scripts": {
     "build": "turbo build",

--- a/packages/csk-cli/package.json
+++ b/packages/csk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-cli",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "description": "Command-line interface (CLI) tool designed to streamline the development workflow within Uniform projects. It provides commands for pulling additional data and generating components based on Canvas data",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/csk-components/package.json
+++ b/packages/csk-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-components",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "description": "Components Starter Kit that provides a set of basic components for building websites within a Uniform project",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/csk-components/src/components/canvas/DemoHero/fixed-hero.tsx
+++ b/packages/csk-components/src/components/canvas/DemoHero/fixed-hero.tsx
@@ -27,8 +27,8 @@ export const FixedHero: FC<FixedHeroProps> = ({ textColor, overlayAutoTint, enab
       // Title Text Parameters
       titleSize={{
         mobile: '3xl',
-        tablet: '5xl',
-        desktop: '5xl',
+        tablet: '4xl',
+        desktop: '4xl',
       }}
       titleWeight="bold"
       titleColor={textColor || props.titleColor}

--- a/packages/csk-recipes/package.json
+++ b/packages/csk-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/csk-recipes",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "description": "command-line interface (CLI) and utility functions to help you work with recipes in a CSK project. It simplifies project initialization by allowing you to choose templates and include specific recipes",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/design-extensions-tools/package.json
+++ b/packages/design-extensions-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniformdev/design-extensions-tools",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "description": "Command-line interface (CLI) tool and a set of utilities for working with design extension integrations",
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/eslint-config",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/typescript-config",
-  "version": "6.0.101",
+  "version": "6.0.102",
   "private": true,
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
This PR addresses feedback from Alex in [SE-615](https://linear.app/uniform/issue/SE-615/coffee-shop-review-hopefully-last), specifically point 4 regarding inconsistent title sizes in Hero components.

Additionally, in [SE-659](https://linear.app/uniform/issue/SE-659/coffee-shop-template-feedback), there’s a request to standardize all Hero title sizes to 4xl on both desktop and tablet breakpoints.

As a result, this PR updates all Hero title sizes to 4xl for consistency across the template, including the Fixed Hero variant.